### PR TITLE
Fix installing ntlk in 2.7 without `languages` extra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,7 @@ matrix:
     sudo: true
   - python: "3.6"
     env: TOXENV="flake8"
+  - python: "3.6"
+    env: TOXENV="black"
 
 after_success: codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix installing ntlk in 2.7 without `languages` extra.
 - Optimize regexes and avoid usage by default.
 
 ## 0.5.7 (2020-04-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Optimize regexes and avoid usage by default.
+
 ## 0.5.7 (2020-04-14)
 
 - Prevent installing an unsupported version of NLTK in Python 2.7.

--- a/lunr/languages/trimmer.py
+++ b/lunr/languages/trimmer.py
@@ -9,14 +9,14 @@ def generate_trimmer(word_characters):
     TODO: lunr-languages ships with lists of word characters for each language
     I haven't found an equivalent in Python, we may need to copy it.
     """
-    start_re = r"^[^{}]+".format(word_characters)
-    end_re = r"[^{}]+$".format(word_characters)
+    full_re = re.compile(r"^[^{0}]*?([{0}]+)[^{0}]*?$".format(word_characters))
 
     def trimmer(token, i=None, tokens=None):
         def trim(s, metadata=None):
-            s = re.sub(start_re, "", s)
-            s = re.sub(end_re, "", s)
-            return s
+            match = full_re.match(s)
+            if match is None:
+                return s
+            return match.group(1)
 
         return token.update(trim)
 

--- a/lunr/query_lexer.py
+++ b/lunr/query_lexer.py
@@ -1,8 +1,6 @@
 from __future__ import unicode_literals
 
-import re
-
-from lunr.tokenizer import SEPARATOR
+from lunr.tokenizer import default_separator
 
 
 class QueryLexer:
@@ -12,7 +10,6 @@ class QueryLexer:
     TERM = "TERM"
     EDIT_DISTANCE = "EDIT_DISTANCE"
     BOOST = "BOOST"
-    TERM_SEPARATOR = SEPARATOR
     PRESENCE = "PRESENCE"
 
     def __init__(self, string):
@@ -154,5 +151,5 @@ class QueryLexer:
                 self.emit(self.PRESENCE)
                 return self.lex_text
 
-            if re.match(self.TERM_SEPARATOR, char):
+            if default_separator(char):
                 return self.lex_term

--- a/lunr/tokenizer.py
+++ b/lunr/tokenizer.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 
-import re
 from builtins import str
 from copy import deepcopy
 
@@ -41,10 +40,10 @@ def Tokenizer(obj, metadata=None, separator=None):
 
     if separator is None:
         is_separator = default_separator
-    elif isinstance(separator, re.Pattern):
-        is_separator = lambda c: separator.match(c)  # noqa
-    else:
+    elif callable(separator):
         is_separator = separator
+    else:  # must be a regex, remove when dropping support for 2.7
+        is_separator = lambda c: separator.match(c)  # noqa
 
     string = str(obj).lower()
     length = len(string)

--- a/lunr/trimmer.py
+++ b/lunr/trimmer.py
@@ -4,15 +4,15 @@ import re
 
 from lunr.pipeline import Pipeline
 
-start_re = re.compile(r"^\W+")
-end_re = re.compile(r"\W+$")
+full_re = re.compile(r"^\W*?([^\W]+)\W*?$")
 
 
 def trimmer(token, i=None, tokens=None):
     def trim(s, metadata=None):
-        s = start_re.sub("", s)
-        s = end_re.sub("", s)
-        return s
+        match = full_re.match(s)
+        if match is None:
+            return s
+        return match.group(1)
 
     return token.update(trim)
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,3 +5,5 @@ pytest-benchmark
 wheel
 mypy
 black
+pdbpp
+ipython

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,11 @@ setup(
     include_package_data=True,
     install_requires=["future>=0.16.0", "six>=1.11.0"],
     extras_require={
-        "languages": ["nltk>=3.2.5"],
-        ":python_version<'3'": ["enum34", "nltk<3.5"],
+        "languages": [
+            "nltk>=3.2.5 ; python_version > '2.7'",
+            "nltk>=3.2.5,<3.5 ; python_version < '3'",
+        ],
+        ":python_version<'3'": ["enum34"],
     },
     keywords="lunr full text search",
     classifiers=[

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,8 +1,9 @@
 from __future__ import unicode_literals
 
-from builtins import str
 import re
+from builtins import str
 
+import pytest
 import six
 
 from lunr.tokenizer import Tokenizer
@@ -82,11 +83,9 @@ class TestTokenizer:
         assert tokens[0].metadata["hurp"] == "durp"
         assert tokens[1].metadata["hurp"] == "durp"
 
-    def test_providing_separator(self):
-        tokens = [
-            str(token)
-            for token in Tokenizer("foo_bar-baz", separator=re.compile(r"[_\-]+"))
-        ]
+    @pytest.mark.parametrize("separator", [re.compile(r"[_\-]+"), lambda c: c in "_-"])
+    def test_providing_separator(self, separator):
+        tokens = [str(token) for token in Tokenizer("foo_bar-baz", separator=separator)]
         assert tokens == ["foo", "bar", "baz"]
 
     def test_tracking_token_position_with_left_hand_whitespace(self):

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,14 @@ commands =
 [testenv:black]
 basepython = python3.6
 deps=
-    -rrequirements/test.txt
     black
-commands={envbindir}/black --check .
+commands={envbindir}/black --check lunr tests
+
+[testenv:flake8]
+basepython = python3.6
+deps=
+    flake8
+commands={envbindir}/flake8 lunr tests
 
 [coverage:run]
 source=lunr
@@ -35,7 +40,7 @@ show_missing = True
 [flake8]
 exclude = lunr/stemmer.py
 max-line-length = 92
-ignore = E203
+ignore = E203 W503
 
 [pytest]
 markers =


### PR DESCRIPTION
Optimize regexes and avoid use by default