### PR TITLE
Index customisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add index customisation, enabling build and search pipeline tweaks as well as
+meta-data whitelisting.
+
 ## 0.5.9 (2021-01-10)
 
 - Compatibility with Lunr.js 2.3.9:

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -1,0 +1,100 @@
+# Customisation
+
+Lunr.py ships with some sensible defaults to create indexes and search easily,
+but in some cases you may want to tweak how documents are indexed and search.
+You can do that in lunr.py by passing your own `Builder` instance to the `lunr`
+function.
+
+## Pipeline functions
+
+When the builder processes your documents it splits (tokenises) the text, and
+applies a series of functions to each token. These are called pipeline functions.
+
+The builder includes two pipelines, indexing and searching.
+
+If you want to change the way lunr.py indexes the documents you'll need to
+change the indexing pipeline.
+
+For example, say you wanted to support the American and British way of spelling
+certain words, you could use a normalisation pipeline function to force one
+token into the other:
+
+```python
+from lunr import lunr, get_default_builder
+import lunr.pipeline.Pipeline
+
+documents = [...]
+
+builder = get_default_builder()
+def normalise_spelling(token, i, tokens) {
+    if str(token) == "gray":
+        return token.update(lambda: "grey")
+    else:
+        return token
+
+lunr.pipeline.Pipeline.register_function(normalise_spelling)
+builder.pipeline.add(normalise_spelling)
+
+idx = lunr(ref="id", fields=("title", "body"), documents=documents, builder=builder)
+```
+
+Note pipeline functions take the token being processed, its position in the
+token list, and the token list itself.
+
+## Token meta-data
+
+Lunr.py `Token` instances include meta-data information which can be used in
+pipeline functions. This meta-data is not stored in the index by default, but it
+can be by adding it to the builder's `metadata_whitelist` property. This will
+include the meta-data in the search results:
+
+```python
+from lunr import lunr, get_default_builder
+import lunr.pipeline.Pipeline
+
+builder = get_default_builder()
+
+def token_length(token, i, tokens):
+    token.metadata["token_length"] = len(str(token))
+    return token
+
+Pipeline.register_function(token_length)
+builder.pipeline.add(token_length)
+builder.metadata_whitelist.append("token_length")
+
+idx = lunr("id", ("title", "body"), documents, builder=builder)
+
+[result, _, _] = idx.search("green")
+assert result["match_data"].metadata["green"]["title"]["token_length"] == [5]
+assert result["match_data"].metadata["green"]["body"]["token_length"] == [5, 5]
+```
+
+## Similarity tuning
+
+The algorithm used by Lunr to calculate similarity between a query and a document
+can be tuned using two parameters. Lunr ships with sensible defaults, and these
+can be adjusted to provide the best results for a given collection of documents.
+
+- **b**: This parameter controls the importance given to the length of a
+document and its fields. This value must be between 0 and 1, and by default it
+has a value of 0.75. Reducing this value reduces the effect of different length
+documents on a term’s importance to that document.
+- **k1**: This controls how quickly the boost given by a common word reaches
+saturation. Increasing it will slow down the rate of saturation and lower values
+result in quicker saturation. The default value is 1.2. If the collection of
+documents being indexed have high occurrences of words that are not covered by
+a stop word filter, these words can quickly dominate any similarity calculation.
+In these cases, this value can be reduced to get more balanced results.
+
+These values can be changed in the builder:
+
+```python
+from lunr import lunr, get_default_builder
+
+builder = get_default_builder()
+builder.k1(1.3)
+builder.b(0)
+
+idx = lunr("id", ("title", "body"), documents, builder=builder)
+```
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,5 +98,6 @@ indices
 languages
 lunrjs-interop
 changelog
+customisation
 GitHub Repository <https://github.com/yeraydiazdiaz/lunr.py>
 ```

--- a/lunr/__init__.py
+++ b/lunr/__init__.py
@@ -1,8 +1,8 @@
 import logging
 
-from lunr.__main__ import lunr
+from lunr.__main__ import lunr, get_default_builder
 
-__all__ = ("lunr",)
+__all__ = ("lunr", "get_default_builder")
 
 logging.basicConfig(format="%(levelname)-7s -  %(message)s")
 

--- a/lunr/__main__.py
+++ b/lunr/__main__.py
@@ -25,6 +25,28 @@ def lunr(ref, fields, documents, languages=None):
     Returns:
         Index: The populated Index ready to search against.
     """
+    builder = get_default_builder(languages)
+    builder.ref(ref)
+    for field in fields:
+        if isinstance(field, dict):
+            builder.field(**field)
+        else:
+            builder.field(field)
+
+    for document in documents:
+        if isinstance(document, (tuple, list)):
+            builder.add(document[0], attributes=document[1])
+        else:
+            builder.add(document)
+
+    return builder.build()
+
+
+def get_default_builder(languages=None):
+    """Creates a new pre-configured instance of Builder.
+
+    Useful as a starting point to tweak the defaults.
+    """
     if languages is not None and lang.LANGUAGE_SUPPORT:
         if isinstance(languages, str):
             languages = [languages]
@@ -44,17 +66,4 @@ def lunr(ref, fields, documents, languages=None):
         builder.pipeline.add(trimmer, stop_word_filter, stemmer)
         builder.search_pipeline.add(stemmer)
 
-    builder.ref(ref)
-    for field in fields:
-        if isinstance(field, dict):
-            builder.field(**field)
-        else:
-            builder.field(field)
-
-    for document in documents:
-        if isinstance(document, (tuple, list)):
-            builder.add(document[0], attributes=document[1])
-        else:
-            builder.add(document)
-
-    return builder.build()
+    return builder

--- a/lunr/__main__.py
+++ b/lunr/__main__.py
@@ -5,7 +5,7 @@ from lunr.trimmer import trimmer
 from lunr.stop_word_filter import stop_word_filter
 
 
-def lunr(ref, fields, documents, languages=None):
+def lunr(ref, fields, documents, languages=None, builder=None):
     """A convenience function to configure and construct a lunr.Index.
 
     Args:
@@ -25,7 +25,7 @@ def lunr(ref, fields, documents, languages=None):
     Returns:
         Index: The populated Index ready to search against.
     """
-    builder = get_default_builder(languages)
+    builder = builder or get_default_builder(languages)
     builder.ref(ref)
     for field in fields:
         if isinstance(field, dict):

--- a/lunr/pipeline.py
+++ b/lunr/pipeline.py
@@ -27,8 +27,8 @@ class Pipeline:
 
     @classmethod
     def register_function(cls, fn, label=None):
-        label = label or fn.__name__
         """Register a function with the pipeline."""
+        label = label or fn.__name__
         if label in cls.registered_functions:
             log.warning("Overwriting existing registered function %s", label)
 

--- a/lunr/pipeline.py
+++ b/lunr/pipeline.py
@@ -26,7 +26,8 @@ class Pipeline:
     # TODO: add iterator methods?
 
     @classmethod
-    def register_function(cls, fn, label):
+    def register_function(cls, fn, label=None):
+        label = label or fn.__name__
         """Register a function with the pipeline."""
         if label in cls.registered_functions:
             log.warning("Overwriting existing registered function %s", label)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -216,6 +216,11 @@ class TestRegisterFunction(BaseTestPipeline):
 
         assert self.fn.label == "fn"
 
+    def test_register_function_adds_defaults_to_name_of_the_function(self):
+        Pipeline.register_function(self.fn)
+
+        assert self.fn.label == self.fn.__name__
+
     def test_register_function_adds_function_to_list_of_registered_functions(self):
         Pipeline.register_function(self.fn, "fn")
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,42 @@
+from lunr import lunr, get_default_builder
+from lunr.stemmer import stemmer
+from lunr.trimmer import trimmer
+from lunr.stop_word_filter import stop_word_filter
+
+documents = [
+    {
+        "id": "a",
+        "title": "Mr. Green kills Colonel Mustard",
+        "body": """Mr. Green killed Colonel Mustard in the study with the
+candlestick. Mr. Green is not a very nice fellow.""",
+        "word_count": 19,
+    },
+    {
+        "id": "b",
+        "title": "Plumb waters plant",
+        "body": "Professor Plumb has a green plant in his study",
+        "word_count": 9,
+    },
+    {
+        "id": "c",
+        "title": "Scarlett helps Professor",
+        "body": """Miss Scarlett watered Professor Plumbs green plant
+while he was away from his office last week.""",
+        "word_count": 16,
+    },
+]
+
+
+def test_get_default_builder():
+    builder = get_default_builder()
+    assert builder.pipeline._stack == [trimmer, stop_word_filter, stemmer]
+    assert builder.search_pipeline._stack == [stemmer]
+
+
+def test_drop_pipeline_function():
+    builder = get_default_builder()
+    builder.pipeline.remove(stemmer)
+
+    idx = lunr("id", ("title", "body"), documents, builder=builder)
+
+    assert idx.search("kill") == []  # no match because "killed" was not stemmed

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -56,6 +56,6 @@ def test_add_token_metadata():
 
     idx = lunr("id", ("title", "body"), documents, builder=builder)
 
-    [result] = idx.search("kill")
-    assert result["match_data"].metadata["kill"]["title"]["token_length"] == [4]
-    assert result["match_data"].metadata["kill"]["body"]["token_length"] == [4]
+    [result, _, _] = idx.search("green")
+    assert result["match_data"].metadata["green"]["title"]["token_length"] == [5]
+    assert result["match_data"].metadata["green"]["body"]["token_length"] == [5, 5]


### PR DESCRIPTION
Allow passing a `Builder` instance to `lunr` enabling the [customisation controls featured in lunr.js](https://lunrjs.com/guides/customising.html), i.e. tweaking pipelines (https://github.com/yeraydiazdiaz/lunr.py/issues/75) and metadata whitelisting (https://github.com/yeraydiazdiaz/lunr.py/issues/77)

Closes #75
Closes #77
