### PR TITLE
Add support for Python 3.10, remove pin to NLTK < 3.5

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "pypy3"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
 
     steps:
       - uses: "actions/checkout@v2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add support for Python 3.10.
+- Remove pin to NLTK < 3.5.
+
 ## 0.6.0 (2021-04-22)
 
 - Add index customisation, enabling build and search pipeline tweaks as well as

--- a/setup.py
+++ b/setup.py
@@ -40,10 +40,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[],
     extras_require={
-        # NLTK 3.5 requires regex which does not ship with all types of wheels
-        # and causes installation issues in mkdocs upstream
-        # https://github.com/mkdocs/mkdocs/issues/2062
-        "languages": ["nltk>=3.2.5,<3.5"]
+        "languages": ["nltk"]
     },
     keywords="lunr full text search",
     classifiers=[
@@ -57,6 +54,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Text Processing",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,pypy3,flake8,black,mypy,docs
+envlist = py36,py37,py38,py39,py310,pypy3,flake8,black,mypy,docs
 
 [testenv]
 deps = -rrequirements/test.txt
@@ -66,4 +66,5 @@ python =
     3.7: py37
     3.8: py38,flake8,black,docs,mypy
     3.9: py39
+    3.10: py310
     pypy3: pypy3


### PR DESCRIPTION
Removing the pin is necessary as NLTK < 3.5 crashes on Python 3.10

Closes #94 