### PR TITLE
Add readthedocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+---
+version: 2
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = "lunr.py"
-copyright = "2022, Yeray Diaz Diaz"
+copyright = "2023, Yeray Diaz Diaz"
 author = "Yeray Diaz Diaz"
 
 
@@ -28,13 +28,13 @@ author = "Yeray Diaz Diaz"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "myst_parser",
     "sphinx.ext.autodoc",
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
-    "myst_parser",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ tests = [
 docs = [
     "furo",
     "myst-parser",
-    "sphinx",
+    "sphinx==7.1.2",  # see https://github.com/pradyunsg/furo/discussions/693
     "sphinx-autobuild",
 ]
 local = [

--- a/tox.ini
+++ b/tox.ini
@@ -23,11 +23,7 @@ commands={envbindir}/flake8 lunr tests
 
 [testenv:docs]
 basepython = python3.10
-deps=
-    furo
-    sphinx
-    sphinx-autobuild
-    myst-parser
+extras = docs
 commands={envbindir}/sphinx-build docs docs/_build/html
 
 [testenv:mypy]


### PR DESCRIPTION
Previously we manually entered the configuration in the RTD settings, which expected a requirements file.

This is much cleaner and uses the 'docs' extra.