### PR TITLE
Enable type checking for users and add types to basic API

### DIFF
--- a/lunr/builder.py
+++ b/lunr/builder.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-
+from typing import Any, Callable, DefaultDict, Dict, Union
 
 from lunr.pipeline import Pipeline
 from lunr.tokenizer import Tokenizer
@@ -13,7 +13,8 @@ from lunr.idf import idf as Idf
 class Field:
     """Represents a field with boost and extractor functions."""
 
-    def __init__(self, field_name, boost=1, extractor=None):
+    def __init__(self, field_name: str, boost: int = 1,
+                 extractor: Union[Callable[[Dict], Any], None] = None):
         self.name = field_name
         self.boost = boost
         self.extractor = extractor
@@ -63,7 +64,8 @@ class Builder:
         """
         self._ref = ref
 
-    def field(self, field_name, boost=1, extractor=None):
+    def field(self, field_name: str, boost: int = 1,
+              extractor: Union[Callable[[Dict], Any], None] = None):
         """Adds a field to the list of document fields that will be indexed.
 
         Every document being indexed should have this field. None values for
@@ -94,7 +96,7 @@ class Builder:
 
         self._fields[field_name] = Field(field_name, boost, extractor)
 
-    def b(self, number):
+    def b(self, number: float):
         """A parameter to tune the amount of field length normalisation that is
         applied when calculating relevance scores.
 
@@ -109,7 +111,7 @@ class Builder:
         else:
             self._b = number
 
-    def k1(self, number):
+    def k1(self, number: float):
         """A parameter that controls the speed at which a rise in term
         frequency results in term frequency saturation.
 
@@ -119,7 +121,7 @@ class Builder:
         """
         self._k1 = number
 
-    def add(self, doc, attributes=None):
+    def add(self, doc: Dict, attributes: Union[Dict, None] = None):
         """Adds a document to the index.
 
         Before adding documents to the index it should have been fully
@@ -146,7 +148,7 @@ class Builder:
             tokens = Tokenizer(field_value)
             terms = self.pipeline.run(tokens, field_name)
             field_ref = FieldRef(doc_ref, field_name)
-            field_terms = defaultdict(int)
+            field_terms: DefaultDict[str, int] = defaultdict(int)
 
             # TODO: field_refs are casted to strings in JS, should we allow
             # FieldRef as keys?
@@ -159,7 +161,7 @@ class Builder:
 
                 field_terms[term_key] += 1
                 if term_key not in self.inverted_index:
-                    posting = {_field_name: {} for _field_name in self._fields}
+                    posting: Dict[str, Union[int, Dict]] = {_field_name: {} for _field_name in self._fields}
                     posting["_index"] = self.term_index
                     self.term_index += 1
                     self.inverted_index[term_key] = posting
@@ -175,7 +177,7 @@ class Builder:
                         metadata_key
                     ].append(metadata)
 
-    def build(self):
+    def build(self) -> Index:
         """Builds the index, creating an instance of `lunr.Index`.
 
         This completes the indexing process and should only be called once all

--- a/lunr/lunr.py
+++ b/lunr/lunr.py
@@ -1,11 +1,17 @@
+from typing import Dict, List, Tuple, Union
+
 from lunr import languages as lang
 from lunr.builder import Builder
+from lunr.index import Index
 from lunr.stemmer import stemmer
 from lunr.trimmer import trimmer
 from lunr.stop_word_filter import stop_word_filter
 
 
-def lunr(ref, fields, documents, languages=None, builder=None):
+def lunr(ref: str, fields: List[Union[str, Dict]],
+         documents: List[Union[Dict, Tuple[Dict, Dict], List[Dict]]],
+         languages: Union[str, List[str], None] = None,
+         builder: Union[Builder, None] = None) -> Index:
     """A convenience function to configure and construct a lunr.Index.
 
     Args:
@@ -21,6 +27,8 @@ def lunr(ref, fields, documents, languages=None, builder=None):
             the document and the second the associated attributes to it.
         languages (str or list, optional): The languages to use if using
             NLTK language support, ignored if NLTK is not available.
+        builder (lunr.builder.Builder, optional): A custom builder to use to
+            create the index.
 
     Returns:
         Index: The populated Index ready to search against.
@@ -42,7 +50,7 @@ def lunr(ref, fields, documents, languages=None, builder=None):
     return builder.build()
 
 
-def get_default_builder(languages=None):
+def get_default_builder(languages: Union[str, List[str], None] = None) -> Builder:
     """Creates a new pre-configured instance of Builder.
 
     Useful as a starting point to tweak the defaults.

--- a/lunr/pipeline.py
+++ b/lunr/pipeline.py
@@ -1,11 +1,14 @@
 from collections import defaultdict
 import logging
-from typing import Callable, Dict, List, Set
+from typing import Callable, Dict, List, Set, Union
 
 from lunr.exceptions import BaseLunrException
 from lunr.token import Token
 
 log = logging.getLogger(__name__)
+
+
+PipelineFunction = Callable[[Token, int, List[Token]], Token]
 
 
 class Pipeline:
@@ -14,11 +17,11 @@ class Pipeline:
 
     """
 
-    registered_functions: Dict[str, Callable] = {}
+    registered_functions: Dict[str, PipelineFunction] = {}
 
     def __init__(self):
-        self._stack: List[Callable] = []
-        self._skip: Dict[Callable, Set[str]] = defaultdict(set)
+        self._stack: List[PipelineFunction] = []
+        self._skip: Dict[PipelineFunction, Set[str]] = defaultdict(set)
 
     def __len__(self):
         return len(self._stack)
@@ -29,17 +32,21 @@ class Pipeline:
     # TODO: add iterator methods?
 
     @classmethod
-    def register_function(cls, fn, label=None):
+    def register_function(cls, fn: PipelineFunction, label: Union[str, None] = None):
         """Register a function with the pipeline."""
         label = label or fn.__name__
         if label in cls.registered_functions:
             log.warning("Overwriting existing registered function %s", label)
 
-        fn.label = label
-        cls.registered_functions[fn.label] = fn
+        # This attribute is purely internal so there's no sense in
+        # exposing it to the user in a type annotation and requiring
+        # them to declare fn in some particular way (see
+        # https://github.com/python/mypy/issues/2087#issuecomment-1672807856)
+        fn.label = label  # type: ignore
+        cls.registered_functions[fn.label] = fn  # type: ignore
 
     @classmethod
-    def load(cls, serialised):
+    def load(cls, serialised: Dict):
         """Loads a previously serialised pipeline."""
         pipeline = cls()
         for fn_name in serialised:
@@ -77,7 +84,7 @@ class Pipeline:
                 )
             )
 
-    def after(self, existing_fn, new_fn):
+    def after(self, existing_fn: PipelineFunction, new_fn: PipelineFunction):
         """Adds a single function after a function that already exists in the
         pipeline."""
         self.warn_if_function_not_registered(new_fn)
@@ -87,7 +94,7 @@ class Pipeline:
         except ValueError as e:
             raise BaseLunrException("Cannot find existing_fn") from e
 
-    def before(self, existing_fn, new_fn):
+    def before(self, existing_fn: PipelineFunction, new_fn: PipelineFunction):
         """Adds a single function before a function that already exists in the
         pipeline.
 
@@ -99,14 +106,14 @@ class Pipeline:
         except ValueError as e:
             raise BaseLunrException("Cannot find existing_fn") from e
 
-    def remove(self, fn):
+    def remove(self, fn: PipelineFunction):
         """Removes a function from the pipeline."""
         try:
             self._stack.remove(fn)
         except ValueError:
             pass
 
-    def skip(self, fn: Callable, field_names: List[str]):
+    def skip(self, fn: PipelineFunction, field_names: List[str]):
         """
         Make the pipeline skip the function based on field name we're processing.
 
@@ -114,7 +121,7 @@ class Pipeline:
         """
         self._skip[fn].update(field_names)
 
-    def run(self, tokens, field_name=None):
+    def run(self, tokens: List[Token], field_name: Union[str, None] = None) -> List[Token]:
         """
         Runs the current list of functions that make up the pipeline against
         the passed tokens.
@@ -127,7 +134,7 @@ class Pipeline:
             # Skip the function based on field name.
             if field_name and field_name in self._skip[fn]:
                 continue
-            results = []
+            results: List[Token] = []
             for i, token in enumerate(tokens):
                 # JS ignores additional arguments to the functions but we
                 # force pipeline functions to declare (token, i, tokens)
@@ -143,7 +150,7 @@ class Pipeline:
 
         return tokens
 
-    def run_string(self, string, metadata=None):
+    def run_string(self, string: str, metadata: Union[Dict, None] = None) -> List[str]:
         """Convenience method for passing a string through a pipeline and
         getting strings out. This method takes care of wrapping the passed
         string in a token and mapping the resulting tokens back to strings.
@@ -157,5 +164,5 @@ class Pipeline:
     def reset(self):
         self._stack = []
 
-    def serialize(self):
-        return [fn.label for fn in self._stack]
+    def serialize(self) -> List[str]:
+        return [fn.label for fn in self._stack]  # type: ignore


### PR DESCRIPTION
Some of the code (pipeline.py) had some types.  But this wasn't super useful because the magical `py.typed` file was not included in the package.

So this adds that, but also adds some types.

I can't totally figure out how to use `Protocol` correctly for pipeline functions but in actual fact they have a fixed signature, and the attributes we add are purely for internal use, so it's `type: ignore` for the time being.