### PR TITLE
Add replace() and __getattr__ to pipeline

### DIFF
--- a/lunr/pipeline.py
+++ b/lunr/pipeline.py
@@ -26,6 +26,13 @@ class Pipeline:
     def __repr__(self):
         return '<Pipeline stack="{}">'.format(",".join(fn.label for fn in self._stack))
 
+    def __getitem__(self, label: str) -> Callable:
+        for fn in self._stack:
+            if hasattr(fn, "label") and fn.label == label:
+                return fn
+        raise BaseLunrException(
+            f"Cannot find registered function {label} in pipeline") from KeyError
+
     # TODO: add iterator methods?
 
     @classmethod
@@ -105,6 +112,14 @@ class Pipeline:
             self._stack.remove(fn)
         except ValueError:
             pass
+
+    def replace(self, existing_fn, new_fn):
+        """Replaces a function in the pipeline with a better one."""
+        try:
+            index = self._stack.index(existing_fn)
+            self._stack[index] = new_fn
+        except ValueError as e:
+            raise BaseLunrException("Cannot find existing_fn") from e
 
     def skip(self, fn: Callable, field_names: List[str]):
         """

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -275,3 +275,27 @@ class TestReset(BaseTestPipeline):
 
         self.pipeline.reset()
         assert len(self.pipeline) == 0
+
+
+class TestAccess(BaseTestPipeline):
+    def test_access_function_in_pipeline(self):
+        Pipeline.register_function(fn, "fn")
+        self.pipeline.add(fn)
+        assert self.pipeline["fn"] == fn
+
+    def test_access_function_not_in_pipeline(self):
+        with pytest.raises(BaseLunrException):
+            _ = self.pipeline["fn"]
+
+
+class TestReplace(BaseTestPipeline):
+    def test_replace_function_in_pipeline(self):
+        Pipeline.register_function(fn, "fn")
+        self.pipeline.add(noop)
+        assert len(self.pipeline) == 1
+        with pytest.raises(BaseLunrException):
+            _ = self.pipeline["fn"]
+
+        self.pipeline.replace(noop, fn)
+        assert len(self.pipeline) == 1
+        assert self.pipeline["fn"] == fn


### PR DESCRIPTION
This allows one to more easily find registered functions (such as the broken language trimmers) in a pipeline and replace them (with less broken ones).  Fixes #155